### PR TITLE
Include README relevant to carvel package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When running Kubeapps on a cluster with Contour installed, it is possible to use
    tanzu package install kubeapps \
       --package-name kubeapps.community.tanzu.vmware.com \
       --version ${KUBEAPPS_PACKAGE_VERSION} \
-      --
+      --values-file my-values.yaml
    ```
 
    > You can get the `${KUBEAPPS_PACKAGE_VERSION}` by running `tanzu


### PR DESCRIPTION
- Add README relevant for Carvel package of Kubeapps.
- Remove 3rd party links.

Just adds the relevant README info. Need to update our own docs for the link to the Kubeapps Components too.
