### PR TITLE
Update DCO for CLA in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,6 @@
 # Contributing to package-for-kubeapps
 
-The package-for-kubeapps project team welcomes contributions from the community. Before you start working with package-for-kubeapps, please
-read our [Developer Certificate of Origin](https://cla.vmware.com/dco). All contributions to this repository must be
-signed as described on that page. Your signature certifies that you wrote the patch or have the right to pass it on
-as an open-source patch.
+The Package for Kubeapps project team welcomes contributions from the community. If you wish to contribute code and you have not signed our contributor license agreement (CLA), our bot will update the issue when you open a Pull Request. For any questions about the CLA process, please refer to our [FAQ](https://cla.vmware.com/faq).
 
 ## Running the `package-kubeapps-version.sh` script locally
 


### PR DESCRIPTION
Apache 2 License requires the use of CLA. Please update the contributing.md and readme.md accordingly and replace the paragraph mentioning the DCO. I've updated by using the template provided by OSPO.