### PR TITLE
Update the `generate_image_lock_file` to include all images in charts.

### DIFF
--- a/packaging-templates/kbld_config.yml
+++ b/packaging-templates/kbld_config.yml
@@ -1,7 +1,0 @@
-apiVersion: kbld.k14s.io/v1alpha1
-kind: Config
-searchRules:
-- keyMatcher:
-    name: value
-  valueMatcher:
-    imageRepo: "docker.io/bitnami/kubeapps-asset-syncer"

--- a/packaging-templates/kbld_fake_deployments.yml
+++ b/packaging-templates/kbld_fake_deployments.yml
@@ -1,0 +1,16 @@
+#@ load("@ytt:data", "data")
+
+#@ images = data.read("images.txt").split()
+
+#@ for image in images:
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fake-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - image: #@ image
+#@ end

--- a/packaging-templates/package.yaml
+++ b/packaging-templates/package.yaml
@@ -20,7 +20,9 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          #! TODO(minelson): set imgpkgBundle with the sha *after* uploading the build?
+          #! The app CR spec allows a tag or digest reference
+          #! for the imgpkgBundle.image.
+          #! See https://carvel.dev/kapp-controller/docs/v0.36.1/app-spec/#docs
           image: #@ data.values.ociRepo + ":" + data.values.version
       template:
       - helmTemplate:


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

This PR fixes #4, using a combination of `yq` to collect all the images specified in the charts, `ytt` to render a bunch of fake deployments referencing those images, then `kbld` as per usual to resolve the image references.

As a check, this is what it generates when run in the existing 8.0.14 release (ie. it just adds the missing images which aren't part of a default deployment):

```
diff --git a/8.0.14/bundle/.imgpkg/images.yml b/8.0.14/bundle/.imgpkg/images.yml
index 3547950..38d406a 100644
--- a/8.0.14/bundle/.imgpkg/images.yml
+++ b/8.0.14/bundle/.imgpkg/images.yml
@@ -1,6 +1,20 @@
 ---
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/bitnami-shell:10-debian-10-r406
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 10-debian-10-r406
+          url: docker.io/bitnami/bitnami-shell:10-debian-10-r406
+  image: index.docker.io/bitnami/bitnami-shell@sha256:4d19a1aa7f9b7dabb5dd3f66314b5acfba5a097dc7df6f03c209af4bd6c2a329
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/bitnami-shell:10-debian-10-r408
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 10-debian-10-r408
+          url: docker.io/bitnami/bitnami-shell:10-debian-10-r408
+  image: index.docker.io/bitnami/bitnami-shell@sha256:efe76a0c5b2ac7d3a091bcdd5261990dbce79437c1d32a097147771ed423c71d
 - annotations:
     kbld.carvel.dev/id: docker.io/bitnami/kubeapps-apis:2.4.5-debian-10-r0
     kbld.carvel.dev/origins: |
@@ -8,6 +22,27 @@ images:
           tag: 2.4.5-debian-10-r0
           url: docker.io/bitnami/kubeapps-apis:2.4.5-debian-10-r0
   image: index.docker.io/bitnami/kubeapps-apis@sha256:0a4f3dbbaf5fb4f7bf82ef600e82333bd242fc23d47c9922ed9906cca71a2372
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/kubeapps-apprepository-controller:2.4.5-scratch-r0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 2.4.5-scratch-r0
+          url: docker.io/bitnami/kubeapps-apprepository-controller:2.4.5-scratch-r0
+  image: index.docker.io/bitnami/kubeapps-apprepository-controller@sha256:cdd67611adaaba8a16a09bb2e072708f1e605337d6c5dfdd03191b0eb4745605
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/kubeapps-asset-syncer:2.4.5-scratch-r0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 2.4.5-scratch-r0
+          url: docker.io/bitnami/kubeapps-asset-syncer:2.4.5-scratch-r0
+  image: index.docker.io/bitnami/kubeapps-asset-syncer@sha256:36cccf5a414e49403dad432a73802e73989c14f24b277f8b0cb57accf6688650
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/kubeapps-assetsvc:2.4.5-scratch-r0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 2.4.5-scratch-r0
+          url: docker.io/bitnami/kubeapps-assetsvc:2.4.5-scratch-r0
+  image: index.docker.io/bitnami/kubeapps-assetsvc@sha256:fdbde0a7d00a0e549651ec6a7938aeefc2c7dc19ab8481a96b73b10bbdafbe94
 - annotations:
     kbld.carvel.dev/id: docker.io/bitnami/kubeapps-dashboard:2.4.5-debian-10-r0
     kbld.carvel.dev/origins: |
@@ -22,6 +57,13 @@ images:
           tag: 2.4.5-scratch-r0
           url: docker.io/bitnami/kubeapps-kubeops:2.4.5-scratch-r0
   image: index.docker.io/bitnami/kubeapps-kubeops@sha256:f465a0fb3f7500200001a393af505a0b44bab9a01a7462fae0610938630e6914
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/kubeapps-pinniped-proxy:2.4.5-debian-10-r0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 2.4.5-debian-10-r0
+          url: docker.io/bitnami/kubeapps-pinniped-proxy:2.4.5-debian-10-r0
+  image: index.docker.io/bitnami/kubeapps-pinniped-proxy@sha256:f30be9df1e63343da432c8dd4945dd47147516b24975f5565565376999e8cb0f
 - annotations:
     kbld.carvel.dev/id: docker.io/bitnami/nginx:1.21.6-debian-10-r91
     kbld.carvel.dev/origins: |
@@ -29,4 +71,46 @@ images:
           tag: 1.21.6-debian-10-r91
           url: docker.io/bitnami/nginx:1.21.6-debian-10-r91
   image: index.docker.io/bitnami/nginx@sha256:eeda65461ef96faebb180fbf08edfa19fcc436b08f0d96ab06d236dd82f46345
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/oauth2-proxy:7.2.1-debian-10-r124
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 7.2.1-debian-10-r124
+          url: docker.io/bitnami/oauth2-proxy:7.2.1-debian-10-r124
+  image: index.docker.io/bitnami/oauth2-proxy@sha256:754db75208d7a4e80ec890a46127f8b02357d15c96721a78fe6450b513264409
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/postgres-exporter:0.10.1-debian-10-r93
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 0.10.1-debian-10-r93
+          url: docker.io/bitnami/postgres-exporter:0.10.1-debian-10-r93
+  image: index.docker.io/bitnami/postgres-exporter@sha256:b8f909f088e0e577b02d13dae5c35c121fc9599c72d9ec0bd0b579bf63abc517
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/postgresql:14.2.0-debian-10-r77
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 14.2.0-debian-10-r77
+          url: docker.io/bitnami/postgresql:14.2.0-debian-10-r77
+  image: index.docker.io/bitnami/postgresql@sha256:f9fa10cb4f28fdedf5908260e43c14ea3ac7dba1afa70f65d40be71a43d6cc9b
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/redis-exporter:1.37.0-debian-10-r39
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 1.37.0-debian-10-r39
+          url: docker.io/bitnami/redis-exporter:1.37.0-debian-10-r39
+  image: index.docker.io/bitnami/redis-exporter@sha256:39440d7d0367b1cf566eb9d5b8a5088c9cbce7e74c6316bbf21396376363c476
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/redis-sentinel:6.2.7-debian-10-r0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 6.2.7-debian-10-r0
+          url: docker.io/bitnami/redis-sentinel:6.2.7-debian-10-r0
+  image: index.docker.io/bitnami/redis-sentinel@sha256:8baff93cbde510583552c92fc778c54c4a2752a2a141491d542fa178e600fce3
+- annotations:
+    kbld.carvel.dev/id: docker.io/bitnami/redis:6.2.7-debian-10-r0
+    kbld.carvel.dev/origins: |
+      - resolved:
+          tag: 6.2.7-debian-10-r0
+          url: docker.io/bitnami/redis:6.2.7-debian-10-r0
+  image: index.docker.io/bitnami/redis@sha256:a97dd274c972cb39c8bfbf6f551fd80a9279b564e4713f4a2f02d213c033ae79
 kind: ImagesLock
```