### PR TITLE
Add Helm plugin and Bitnami repo for defaults

### DIFF
--- a/packaging-templates/default-values.yaml
+++ b/packaging-templates/default-values.yaml
@@ -1,5 +1,9 @@
 packaging:
   helm:
-    enabled: false
+    enabled: true
   carvel:
     enabled: true
+apprepository:
+  initialRepos:
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
**Description**

This PR enables the Helm plugin and adds the Bitnami repo by default.
Even if the Bitnami repo was in the bundled config values (e.g. [here](https://github.com/vmware-tanzu/package-for-kubeapps/blob/main/8.1.7/bundle/config/kubeapps/values.yaml#L891)), I preferred to explicitly add it here to be more clear for our future selves.
Happy to remove it, though.